### PR TITLE
Refactor adding amount to transaction from `getExpenseTransactionBody`

### DIFF
--- a/main.py
+++ b/main.py
@@ -366,6 +366,24 @@ def getExpenseTransactionBody(exp: Expense, myshare: ExpenseUser, data: list[str
         f"Processing {category} {formatExpense(exp, myshare)} from {source} to {dest}")
     return newTxn
 
+def applyExpenseAmountToTransaction(transaction: dict, exp: Expense, myshare: ExpenseUser) -> dict:
+    """Apply the amount to the transaction based on the currency of the account.
+    
+    :param transaction: The transaction dictionary
+    :param exp: The Splitwise expense
+    :param myshare: The user's share in the expense
+    :return: The updated transaction dictionary
+    """
+    amount = myshare.getOwedShare()
+    if getAccountCurrencyCode(transaction["source_name"]) == exp.getCurrencyCode():
+        transaction["amount"] = amount
+    else:
+        transaction["foreign_currency_code"] = exp.getCurrencyCode()
+        transaction["foreign_amount"] = amount
+        transaction["amount"] = 0.1
+        transaction["tags"].append(conf["FOREIGN_CURRENCY_TOFIX_TAG"])
+
+
 def getAccounts(account_type: str="asset") -> list:
     """Get accounts from Firefly.
 

--- a/main.py
+++ b/main.py
@@ -349,19 +349,15 @@ def getExpenseTransactionBody(exp: Expense, myshare: ExpenseUser, data: list[str
         "destination_name": dest,
         "category_name": category,
         "type": "withdrawal",
-        "amount": myshare.getOwedShare(),
         "date": getDate(exp.getCreatedAt()).isoformat(),
         "payment_date": getDate(exp.getDate()).isoformat(),
         "description": description,
         "reconciled": False,
         "notes": notes,
         "external_url": getSWUrlForExpense(exp),
+        "tags": [],
     }
-    if getAccountCurrencyCode(source) != exp.getCurrencyCode():
-        newTxn["foreign_currency_code"] = exp.getCurrencyCode()
-        newTxn["foreign_amount"] = myshare.getOwedShare()
-        newTxn["amount"] = 0.1
-        newTxn["tags"] = [conf["FOREIGN_CURRENCY_TOFIX_TAG"]] 
+    newTxn = applyExpenseAmountToTransaction(newTxn, exp, myshare)
     print(
         f"Processing {category} {formatExpense(exp, myshare)} from {source} to {dest}")
     return newTxn


### PR DESCRIPTION
Refactor code to add amount to transaction in a currency-aware manner out of `getExpenseTransactionBody`.
This simplifies `getExpenseTransactionBody`, and also allows us to use currency-aware amount adding in other parts (such as in the different txn strategies mentioned in #9).